### PR TITLE
Handle UINT16 the same as RGB16/RGBA16

### DIFF
--- a/src/image.hpp
+++ b/src/image.hpp
@@ -223,7 +223,7 @@ public:
 	bool convertTo32Bits() {
 		if (image_.convertTo32Bits())
 			return true;
-		return image_.convertToType(FIT_BITMAP) && image_.convertTo32Bits();
+		return image_.convertTo8Bits() && image_.convertTo32Bits();
 	}
 	bool load(const std::wstring& filename) { return !!image_.loadU(filename.c_str()); }
 	bool save(const std::wstring& filename)


### PR DESCRIPTION
convertToType() will scale depending on image content, convertTo8Bits() will divide by 256, just like convertTo32Bits()

See https://github.com/WinMerge/winimerge/issues/6#issuecomment-590941179