### PR TITLE
Add option to prefer WIC for image decoding refs #37

### DIFF
--- a/src/WinIMerge/WinIMerge.cpp
+++ b/src/WinIMerge/WinIMerge.cpp
@@ -215,6 +215,7 @@ void SaveImageAs(HWND hWnd, int pane)
 void UpdateMenuState(HWND hWnd)
 {
 	HMENU hMenu = GetMenu(hWnd);
+	CheckMenuItem(hMenu, ID_FILE_PREFER_WIC_DECODER, m_pImgMergeWindow->GetPreferWICDecoder() ? MF_CHECKED : MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_VIEWDIFFERENCES,    m_pImgMergeWindow->GetShowDifferences() ? MF_CHECKED : MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_BLINKDIFFERENCES,    m_pImgMergeWindow->GetBlinkDifferences() ? MF_CHECKED : MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_SPLITHORIZONTALLY,  m_pImgMergeWindow->GetHorizontalSplit() ? MF_CHECKED : MF_UNCHECKED);
@@ -539,6 +540,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			}
 			break;
 		}
+		case ID_FILE_PREFER_WIC_DECODER:
+			m_pImgMergeWindow->SetPreferWICDecoder(!m_pImgMergeWindow->GetPreferWICDecoder());
+			break;
 		case ID_FILE_EXIT:
 			DestroyWindow(hWnd);
 			break;

--- a/src/WinIMerge/WinIMerge.rc
+++ b/src/WinIMerge/WinIMerge.rc
@@ -80,6 +80,7 @@ BEGIN
             MENUITEM "Save &Middle As...",          ID_FILE_SAVE_MIDDLE_AS
             MENUITEM "Save &Right As...",           ID_FILE_SAVE_RIGHT_AS
         END
+        MENUITEM "&Prefer WIC Decoder",         ID_FILE_PREFER_WIC_DECODER
         MENUITEM "&Generate Report...",         ID_FILE_GENERATE_REPORT
         MENUITEM SEPARATOR
         MENUITEM "Re&load\tCtrl+F5",            ID_FILE_RELOAD

--- a/src/WinIMerge/resource.h
+++ b/src/WinIMerge/resource.h
@@ -9,10 +9,11 @@
 #define ID_FILE_OPEN                    106
 #define ID_FILE_OPEN3                   107
 #define ID_FILE_GENERATE_REPORT         108
-#define ID_FILE_EXIT                    109
-#define IDI_WINIMERGE                   110
-#define IDC_WINIMERGE                   111
-#define IDC_DIFFMAP                     112
+#define ID_FILE_PREFER_WIC_DECODER      109
+#define ID_FILE_EXIT                    110
+#define IDI_WINIMERGE                   111
+#define IDC_WINIMERGE                   112
+#define IDC_DIFFMAP                     113
 #define IDR_MAINFRAME                   128
 #define IDR_POPUPMENU                   130
 #define IDS_DIFF_GROUP                  131

--- a/src/WinIMergeLib/ImgDiffBuffer.hpp
+++ b/src/WinIMergeLib/ImgDiffBuffer.hpp
@@ -1955,7 +1955,7 @@ protected:
 
 		if (m_wipeMode == WIPE_VERTICAL)
 		{
-			if (m_wipePosition >= h)
+			if (m_wipePosition >= static_cast<int>(h))
 				m_wipePosition = h;
 			if (m_wipePosition_old == INT_MAX)
 				m_wipePosition_old = h;
@@ -1963,7 +1963,7 @@ protected:
 			std::vector<unsigned char> tmp(lineBytes);
 			if (m_wipePosition <= m_wipePosition_old)
 			{
-				for (unsigned y = m_wipePosition; y < m_wipePosition_old; ++y)
+				for (int y = m_wipePosition; y < m_wipePosition_old; ++y)
 				{
 					for (int pane = 0; pane < m_nImages - 1; ++pane)
 					{
@@ -1977,7 +1977,7 @@ protected:
 			}
 			else
 			{
-				for (unsigned y = m_wipePosition_old; y < m_wipePosition; ++y)
+				for (int y = m_wipePosition_old; y < m_wipePosition; ++y)
 				{
 					for (int pane = m_nImages - 1; pane > 0; --pane)
 					{
@@ -1992,7 +1992,7 @@ protected:
 		}
 		else if (m_wipeMode == WIPE_HORIZONTAL)
 		{
-			if (m_wipePosition >= w)
+			if (m_wipePosition >= static_cast<int>(w))
 				m_wipePosition = w;
 			if (m_wipePosition_old == INT_MAX)
 				m_wipePosition_old = w;
@@ -2010,7 +2010,7 @@ protected:
 					{
 						scanline = m_imgDiff[pane].scanLine(y);
 						scanline2 = m_imgDiff[pane + 1].scanLine(y);
-						for (unsigned x = m_wipePosition; x < m_wipePosition_old; ++x)
+						for (int x = m_wipePosition; x < m_wipePosition_old; ++x)
 						{
 							memcpy(tmp, scanline + x * pixelBytes, pixelBytes);
 							memcpy(scanline + x * pixelBytes, scanline2 + x * pixelBytes, pixelBytes);
@@ -2021,7 +2021,7 @@ protected:
 					{
 						scanline = m_imgDiff[m_nImages - 2 - pane].scanLine(y);
 						scanline2 = m_imgDiff[m_nImages - 1 - pane].scanLine(y);
-						for (unsigned x = m_wipePosition_old; x < m_wipePosition; ++x)
+						for (int x = m_wipePosition_old; x < m_wipePosition; ++x)
 						{
 							memcpy(tmp, scanline + x * pixelBytes, pixelBytes);
 							memcpy(scanline + x * pixelBytes, scanline2 + x * pixelBytes, pixelBytes);

--- a/src/WinIMergeLib/ImgDiffBuffer.hpp
+++ b/src/WinIMergeLib/ImgDiffBuffer.hpp
@@ -510,6 +510,7 @@ public:
 		, m_diffDeletedColor(Image::Rgb(0xc0, 0xc0, 0xc0))
 		, m_diffColorAlpha(0.7)
 		, m_colorDistanceThreshold(0.0)
+		, m_preferWICDecoder(false)
 		, m_currentDiffIndex(-1)
 		, m_diffCount(0)
 		, m_angle{}
@@ -944,6 +945,16 @@ public:
 			return;
 		m_diffAlgorithm = diffAlgorithm;
 		CompareImages();
+	}
+
+	bool GetPreferWICDecoder() const
+	{
+		return m_preferWICDecoder;
+	}
+
+	void SetPreferWICDecoder(bool preferWIC)
+	{
+		m_preferWICDecoder = preferWIC;
 	}
 
 	const DiffInfo *GetDiffInfo(int diffIndex) const
@@ -1580,9 +1591,16 @@ protected:
 			else
 			{
 				m_imgOrigMultiPage[i].close();
-				if (!m_imgOrig[i].load(m_filename[i]))
+				bool bLoaded = false;
+				const bool useWIC = m_preferWICDecoder && ImgConverter::isSupportedImage(m_filename[i].c_str());
+				if (useWIC && m_imgConverter[i].load(m_filename[i].c_str()))
 				{
-					if (ImgConverter::isSupportedImage(m_filename[i].c_str()))
+					m_imgConverter[i].render(m_imgOrig[i], 0, m_vectorImageZoomRatio);
+					bLoaded = true;
+				}
+				if (!bLoaded && !m_imgOrig[i].load(m_filename[i]))
+				{
+					if (!useWIC && ImgConverter::isSupportedImage(m_filename[i].c_str()))
 					{
 						if (m_imgConverter[i].load(m_filename[i].c_str()))
 							m_imgConverter[i].render(m_imgOrig[i], 0, m_vectorImageZoomRatio);
@@ -2391,4 +2409,5 @@ protected:
 	int m_overlayAnimationInterval;
 	int m_lastErrorCode;
 	bool m_imgDiffIsTransparent[3]{};
+	bool m_preferWICDecoder;
 };

--- a/src/WinIMergeLib/ImgMergeWindow.hpp
+++ b/src/WinIMergeLib/ImgMergeWindow.hpp
@@ -664,7 +664,7 @@ public:
 		int pane = GetActivePane();
 		if (pane < 0)
 			return false;
-		return !!IsClipboardFormatAvailable(CF_DIBV5);
+		return !!IsClipboardFormatAvailable(CF_DIB);
 	}
 
 	bool IsRedoable() const override

--- a/src/WinIMergeLib/ImgMergeWindow.hpp
+++ b/src/WinIMergeLib/ImgMergeWindow.hpp
@@ -497,6 +497,16 @@ public:
 		Invalidate();
 	}
 
+	bool GetPreferWICDecoder() const override
+	{
+		return m_buffer.GetPreferWICDecoder();
+	}
+
+	void SetPreferWICDecoder(bool preferred) override
+	{
+		m_buffer.SetPreferWICDecoder(preferred);
+	}
+
 	int  GetDiffCount() const override
 	{
 		return m_buffer.GetDiffCount();
@@ -654,7 +664,7 @@ public:
 		int pane = GetActivePane();
 		if (pane < 0)
 			return false;
-		return !!IsClipboardFormatAvailable(CF_DIB);
+		return !!IsClipboardFormatAvailable(CF_DIBV5);
 	}
 
 	bool IsRedoable() const override

--- a/src/WinIMergeLib/WinIMergeLib.h
+++ b/src/WinIMergeLib/WinIMergeLib.h
@@ -190,6 +190,8 @@ struct IImgMergeWindow
 	virtual bool IsDarkBackgroundEnabled() const = 0;
 	virtual void SetDarkBackgroundEnabled(bool enabled) = 0;
 	virtual int GetLastErrorCode() const = 0;
+	virtual bool GetPreferWICDecoder() const = 0;
+	virtual void SetPreferWICDecoder(bool preferWICDecoder) = 0;
 };
 
 struct IImgToolWindow

--- a/src/WinIMergeLib/resource.h
+++ b/src/WinIMergeLib/resource.h
@@ -9,10 +9,11 @@
 #define ID_FILE_OPEN                    106
 #define ID_FILE_OPEN3                   107
 #define ID_FILE_GENERATE_REPORT         108
-#define ID_FILE_EXIT                    109
-#define IDI_WINIMERGE                   110
-#define IDC_WINIMERGE                   111
-#define IDC_DIFFMAP                     112
+#define ID_FILE_PREFER_WIC_DECODER      109
+#define ID_FILE_EXIT                    110
+#define IDI_WINIMERGE                   111
+#define IDC_WINIMERGE                   112
+#define IDC_DIFFMAP                     113
 #define IDR_MAINFRAME                   128
 #define IDR_POPUPMENU                   130
 #define IDS_DIFF_GROUP                  131


### PR DESCRIPTION
Add an option to prefer WIC over FreeImage when decoding images.

This allows images that are decoded differently by FreeImage to be loaded using the Windows Imaging Component (WIC) instead.